### PR TITLE
Enable <loadFromRemoteSources> to avoid FileLoadException

### DIFF
--- a/Source/Editor/app.config
+++ b/Source/Editor/app.config
@@ -15,4 +15,7 @@
             </setting>
         </ChristianHelle.DatabaseTools.SqlCe.QueryAnalyzer.Properties.Settings>
     </userSettings>
+    <runtime>
+        <loadFromRemoteSources enabled="true"/>
+    </runtime>
 </configuration>


### PR DESCRIPTION
Enable <loadFromRemoteSources> to avoid FileLoadException when using the portable binaries