### PR TITLE
Restore informative message on SQL syntax error

### DIFF
--- a/Source/TSqlParser/TSqlParser.cs
+++ b/Source/TSqlParser/TSqlParser.cs
@@ -22,20 +22,30 @@ namespace ChristianHelle.DatabaseTools.SqlCe.TSqlParser {
 
             if (parser.tsql_file() is var ctxt) {
                 bool b_error = false;
+                int cur_char_idx = 0;
                 foreach (var batch in ctxt?.children) {
                     for (int i = 0; i < batch.ChildCount && !b_error; i++) {
                         var stmt_tree = batch.GetChild(i);
                         var stmt = stmt_tree.Payload as TSqlParserCore.Sql_clausesContext;
 
-                        var start_idx = stmt.Start.StartIndex;
-
+                        int start_idx;
                         int stop_idx;
-                        if (stmt.Stop is null) {
+                        if (stmt is null) {
                             b_error = true;
+                            start_idx = cur_char_idx;
                             stop_idx = s.Length - 1;
                         } else {
-                            stop_idx = stmt.Stop.StopIndex;
+                            start_idx = stmt.Start.StartIndex;
+
+                            if (stmt.Stop is null) {
+                                b_error = true;
+                                stop_idx = s.Length - 1;
+                            } else {
+                                stop_idx = stmt.Stop.StopIndex;
+                                cur_char_idx = stop_idx + 1;
+                            }
                         }
+
                         var stmt_s = s.Substring(start_idx, stop_idx - start_idx + 1);
                         stmts.Add(stmt_s);
                     }

--- a/Source/TSqlParser/TSqlParser.cs
+++ b/Source/TSqlParser/TSqlParser.cs
@@ -21,18 +21,26 @@ namespace ChristianHelle.DatabaseTools.SqlCe.TSqlParser {
             //parser.BuildParseTree = true;
 
             if (parser.tsql_file() is var ctxt) {
+                bool b_error = false;
                 foreach (var batch in ctxt?.children) {
-                    for (int i = 0; i < batch.ChildCount; i++) {
-                        var stmt = batch.GetChild(i);
+                    for (int i = 0; i < batch.ChildCount && !b_error; i++) {
+                        var stmt_tree = batch.GetChild(i);
+                        var stmt = stmt_tree.Payload as TSqlParserCore.Sql_clausesContext;
 
-                        var stmt_s = "";
-                        var prefix = "";
-                        for (int j = stmt.SourceInterval.a; j <= stmt.SourceInterval.b; j++) {
-                            stmt_s += $"{prefix}{tokens.Get(j).Text}";
-                            prefix = " ";
+                        var start_idx = stmt.Start.StartIndex;
+
+                        int stop_idx;
+                        if (stmt.Stop is null) {
+                            b_error = true;
+                            stop_idx = s.Length - 1;
+                        } else {
+                            stop_idx = stmt.Stop.StopIndex;
                         }
-
+                        var stmt_s = s.Substring(start_idx, stop_idx - start_idx + 1);
                         stmts.Add(stmt_s);
+                    }
+                    if (b_error) {
+                        break;
                     }
                 }
             }


### PR DESCRIPTION
Follow-up from PR #17 

I just had a revelation last night that because I’m excluding everything that isn’t a statement, we'd be crashing horribly if the query has syntax errors… and indeed, it does.

So here I’ve tried to replicate the previous behavior which let the SqlServer library describe the error to the user.

Essentially, I add statements like before except that if something doesn’t work, I make the whole remaining string a statement so the error will be informative to the user.