### PR TITLE
Fix DateTime display to show seconds in table data

### DIFF
--- a/Source/Editor/Controls/DataGridViewEx.cs
+++ b/Source/Editor/Controls/DataGridViewEx.cs
@@ -31,8 +31,24 @@ namespace ChristianHelle.DatabaseTools.SqlCe.QueryAnalyzer.Controls
 
         protected override void OnCellFormatting(DataGridViewCellFormattingEventArgs e)
         {
-            e.CellStyle.Font = e.Value == DBNull.Value ? italicFont : normalFont;
-            e.CellStyle.ForeColor = e.Value == DBNull.Value ? SystemColors.GrayText : SystemColors.WindowText;
+            if (e.Value == DBNull.Value)
+            {
+                e.CellStyle.Font = italicFont;
+                e.CellStyle.ForeColor = SystemColors.GrayText;
+            }
+            else
+            {
+                e.CellStyle.Font = normalFont;
+                e.CellStyle.ForeColor = SystemColors.WindowText;
+                
+                // Format DateTime values to include seconds
+                if (e.Value is DateTime dateTimeValue)
+                {
+                    e.Value = dateTimeValue.ToString("yyyy-MM-dd HH:mm:ss");
+                    e.FormattingApplied = true;
+                }
+            }
+            
             base.OnCellFormatting(e);
         }
 


### PR DESCRIPTION
This pull request improves the cell formatting logic in the `DataGridViewEx` control to better handle `DateTime` values and clarify conditional formatting. The main change is the addition of custom formatting for `DateTime` values to display seconds, along with a refactor for readability.

Enhancements to cell formatting:

* Refactored the conditional logic in `OnCellFormatting` to use explicit if/else blocks, improving code clarity and maintainability.
* Added custom formatting for `DateTime` cell values to display them in the `yyyy-MM-dd HH:mm:ss` format, ensuring seconds are included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Date/time values in data grids now display consistently as YYYY-MM-DD HH:MM:SS.
  * Null/empty cells render distinctly to avoid confusion with real values.

* **Style**
  * Improved cell font and color styling for clearer visual differentiation between empty and populated cells.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Fixes #10 